### PR TITLE
feat(frontend): add API proxies migrated from merge-sensey

### DIFF
--- a/frontend/src/app/proxy/ai-models/ai-model.service.ts
+++ b/frontend/src/app/proxy/ai-models/ai-model.service.ts
@@ -1,0 +1,56 @@
+import type { AiModelDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AiModelService {
+  apiName = 'Default';
+  
+
+  create = (input: AiModelDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, AiModelDto>({
+      method: 'POST',
+      url: '/api/app/ai-model',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: number, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/ai-model/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: number, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, AiModelDto>({
+      method: 'GET',
+      url: `/api/app/ai-model/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<AiModelDto>>({
+      method: 'GET',
+      url: '/api/app/ai-model',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: number, input: AiModelDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, AiModelDto>({
+      method: 'PUT',
+      url: `/api/app/ai-model/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/frontend/src/app/proxy/ai-models/dtos/index.ts
+++ b/frontend/src/app/proxy/ai-models/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/ai-models/dtos/models.ts
+++ b/frontend/src/app/proxy/ai-models/dtos/models.ts
@@ -1,0 +1,6 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface AiModelDto extends EntityDto<number> {
+  name?: string;
+  vendor?: string;
+}

--- a/frontend/src/app/proxy/ai-models/index.ts
+++ b/frontend/src/app/proxy/ai-models/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './ai-model.service';
+export { Dtos };

--- a/frontend/src/app/proxy/groups/dtos/index.ts
+++ b/frontend/src/app/proxy/groups/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/groups/dtos/models.ts
+++ b/frontend/src/app/proxy/groups/dtos/models.ts
@@ -1,0 +1,6 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface GroupDto extends EntityDto<string> {
+  name?: string;
+  description?: string;
+}

--- a/frontend/src/app/proxy/groups/group.service.ts
+++ b/frontend/src/app/proxy/groups/group.service.ts
@@ -1,0 +1,56 @@
+import type { GroupDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GroupService {
+  apiName = 'Default';
+  
+
+  create = (input: GroupDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, GroupDto>({
+      method: 'POST',
+      url: '/api/app/group',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/group/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, GroupDto>({
+      method: 'GET',
+      url: `/api/app/group/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<GroupDto>>({
+      method: 'GET',
+      url: '/api/app/group',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: string, input: GroupDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, GroupDto>({
+      method: 'PUT',
+      url: `/api/app/group/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/frontend/src/app/proxy/groups/index.ts
+++ b/frontend/src/app/proxy/groups/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './group.service';
+export { Dtos };

--- a/frontend/src/app/proxy/index.ts
+++ b/frontend/src/app/proxy/index.ts
@@ -1,5 +1,12 @@
+import * as AiModels from './ai-models';
+import * as Branches from './branches';
+import * as Groups from './groups';
+import * as NodeTypes from './node-types';
+import * as Nodes from './nodes';
+import * as Pipelines from './pipelines';
 import * as Projects from './projects';
 import * as Repositories from './repositories';
-import * as Branches from './branches';
+import * as TriggerTypes from './trigger-types';
+import * as Triggers from './triggers';
 
-export { Projects, Repositories, Branches };
+export { AiModels, Branches, Groups, NodeTypes, Nodes, Pipelines, Projects, Repositories, TriggerTypes, Triggers };

--- a/frontend/src/app/proxy/node-types/dtos/index.ts
+++ b/frontend/src/app/proxy/node-types/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/node-types/dtos/models.ts
+++ b/frontend/src/app/proxy/node-types/dtos/models.ts
@@ -1,0 +1,6 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface NodeTypeDto extends EntityDto<number> {
+  name?: string;
+  modelId?: string;
+}

--- a/frontend/src/app/proxy/node-types/index.ts
+++ b/frontend/src/app/proxy/node-types/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './node-type.service';
+export { Dtos };

--- a/frontend/src/app/proxy/node-types/node-type.service.ts
+++ b/frontend/src/app/proxy/node-types/node-type.service.ts
@@ -1,0 +1,56 @@
+import type { NodeTypeDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NodeTypeService {
+  apiName = 'Default';
+  
+
+  create = (input: NodeTypeDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, NodeTypeDto>({
+      method: 'POST',
+      url: '/api/app/node-type',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: number, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/node-type/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: number, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, NodeTypeDto>({
+      method: 'GET',
+      url: `/api/app/node-type/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<NodeTypeDto>>({
+      method: 'GET',
+      url: '/api/app/node-type',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: number, input: NodeTypeDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, NodeTypeDto>({
+      method: 'PUT',
+      url: `/api/app/node-type/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/frontend/src/app/proxy/nodes/dtos/index.ts
+++ b/frontend/src/app/proxy/nodes/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/nodes/dtos/models.ts
+++ b/frontend/src/app/proxy/nodes/dtos/models.ts
@@ -1,0 +1,5 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface NodeDto extends EntityDto<string> {
+  typeId: number;
+}

--- a/frontend/src/app/proxy/nodes/index.ts
+++ b/frontend/src/app/proxy/nodes/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './node.service';
+export { Dtos };

--- a/frontend/src/app/proxy/nodes/node.service.ts
+++ b/frontend/src/app/proxy/nodes/node.service.ts
@@ -1,0 +1,56 @@
+import type { NodeDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NodeService {
+  apiName = 'Default';
+  
+
+  create = (input: NodeDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, NodeDto>({
+      method: 'POST',
+      url: '/api/app/node',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/node/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, NodeDto>({
+      method: 'GET',
+      url: `/api/app/node/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<NodeDto>>({
+      method: 'GET',
+      url: '/api/app/node',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: string, input: NodeDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, NodeDto>({
+      method: 'PUT',
+      url: `/api/app/node/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/frontend/src/app/proxy/pipelines/dtos/index.ts
+++ b/frontend/src/app/proxy/pipelines/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/pipelines/dtos/models.ts
+++ b/frontend/src/app/proxy/pipelines/dtos/models.ts
@@ -1,0 +1,8 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface PipelineDto extends EntityDto<string> {
+  status?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  duration?: number;
+}

--- a/frontend/src/app/proxy/pipelines/index.ts
+++ b/frontend/src/app/proxy/pipelines/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './pipeline.service';
+export { Dtos };

--- a/frontend/src/app/proxy/pipelines/pipeline.service.ts
+++ b/frontend/src/app/proxy/pipelines/pipeline.service.ts
@@ -1,0 +1,56 @@
+import type { PipelineDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PipelineService {
+  apiName = 'Default';
+  
+
+  create = (input: PipelineDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PipelineDto>({
+      method: 'POST',
+      url: '/api/app/pipeline',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/pipeline/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PipelineDto>({
+      method: 'GET',
+      url: `/api/app/pipeline/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<PipelineDto>>({
+      method: 'GET',
+      url: '/api/app/pipeline',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: string, input: PipelineDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PipelineDto>({
+      method: 'PUT',
+      url: `/api/app/pipeline/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/frontend/src/app/proxy/trigger-types/dtos/index.ts
+++ b/frontend/src/app/proxy/trigger-types/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/trigger-types/dtos/models.ts
+++ b/frontend/src/app/proxy/trigger-types/dtos/models.ts
@@ -1,0 +1,5 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface TriggerTypeDto extends EntityDto<number> {
+  name?: string;
+}

--- a/frontend/src/app/proxy/trigger-types/index.ts
+++ b/frontend/src/app/proxy/trigger-types/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './trigger-type.service';
+export { Dtos };

--- a/frontend/src/app/proxy/trigger-types/trigger-type.service.ts
+++ b/frontend/src/app/proxy/trigger-types/trigger-type.service.ts
@@ -1,0 +1,56 @@
+import type { TriggerTypeDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TriggerTypeService {
+  apiName = 'Default';
+  
+
+  create = (input: TriggerTypeDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, TriggerTypeDto>({
+      method: 'POST',
+      url: '/api/app/trigger-type',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: number, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/trigger-type/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: number, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, TriggerTypeDto>({
+      method: 'GET',
+      url: `/api/app/trigger-type/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<TriggerTypeDto>>({
+      method: 'GET',
+      url: '/api/app/trigger-type',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: number, input: TriggerTypeDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, TriggerTypeDto>({
+      method: 'PUT',
+      url: `/api/app/trigger-type/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}

--- a/frontend/src/app/proxy/triggers/dtos/index.ts
+++ b/frontend/src/app/proxy/triggers/dtos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/frontend/src/app/proxy/triggers/dtos/models.ts
+++ b/frontend/src/app/proxy/triggers/dtos/models.ts
@@ -1,0 +1,7 @@
+import type { EntityDto } from '@abp/ng.core';
+
+export interface TriggerDto extends EntityDto<string> {
+  branchId?: string;
+  repositoryId?: string;
+  typeId: number;
+}

--- a/frontend/src/app/proxy/triggers/index.ts
+++ b/frontend/src/app/proxy/triggers/index.ts
@@ -1,0 +1,3 @@
+import * as Dtos from './dtos';
+export * from './trigger.service';
+export { Dtos };

--- a/frontend/src/app/proxy/triggers/trigger.service.ts
+++ b/frontend/src/app/proxy/triggers/trigger.service.ts
@@ -1,0 +1,56 @@
+import type { TriggerDto } from './dtos/models';
+import { RestService, Rest } from '@abp/ng.core';
+import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TriggerService {
+  apiName = 'Default';
+  
+
+  create = (input: TriggerDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, TriggerDto>({
+      method: 'POST',
+      url: '/api/app/trigger',
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  delete = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, void>({
+      method: 'DELETE',
+      url: `/api/app/trigger/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  get = (id: string, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, TriggerDto>({
+      method: 'GET',
+      url: `/api/app/trigger/${id}`,
+    },
+    { apiName: this.apiName,...config });
+  
+
+  getList = (input: PagedAndSortedResultRequestDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, PagedResultDto<TriggerDto>>({
+      method: 'GET',
+      url: '/api/app/trigger',
+      params: { sorting: input.sorting, skipCount: input.skipCount, maxResultCount: input.maxResultCount },
+    },
+    { apiName: this.apiName,...config });
+  
+
+  update = (id: string, input: TriggerDto, config?: Partial<Rest.Config>) =>
+    this.restService.request<any, TriggerDto>({
+      method: 'PUT',
+      url: `/api/app/trigger/${id}`,
+      body: input,
+    },
+    { apiName: this.apiName,...config });
+
+  constructor(private restService: RestService) {}
+}


### PR DESCRIPTION
## Summary
- migrate ABP proxies for pipelines, nodes, triggers, groups, and AI models into unified proxy set
- expose newly migrated proxies via `frontend/src/app/proxy/index.ts`
- ensure environment config uses expected API, issuer, client ID, and scope

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c089fb7d888321aed2972852898077