### PR TITLE
feat(frontend): toast service and HTTP interceptors (from merge-sensey)

### DIFF
--- a/frontend/src/app/core/interceptors/http-error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/http-error.interceptor.ts
@@ -1,0 +1,29 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+import { ToastService } from '../toast/toast.service';
+
+export const httpErrorInterceptor: HttpInterceptorFn = (req, next) => {
+  const toast = inject(ToastService);
+  const router = inject(Router);
+
+  return next(req).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status >= 400) {
+        const message =
+          (error.error && (error.error.error?.message || error.error.message)) ||
+          error.statusText ||
+          'Error';
+
+        toast.error({ message });
+
+        if (error.status === 401 || error.status === 403) {
+          router.navigate(['/account/login']);
+        }
+      }
+
+      return throwError(() => error);
+    }),
+  );
+};

--- a/frontend/src/app/core/toast/toast.animation.ts
+++ b/frontend/src/app/core/toast/toast.animation.ts
@@ -1,0 +1,14 @@
+import { animate, style, transition, trigger } from '@angular/animations';
+
+export const toastAnimation = [
+  trigger('toastFadeIn', [
+    transition(':enter', [
+      style({ opacity: '0', transform: 'translateY(calc(100% - 1rem))' }),
+      animate('0.2s ease-out', style({ opacity: '1', transform: 'translateY(0)' })),
+    ]),
+    transition(':leave', [
+      style({ opacity: '1' }),
+      animate('0.2s ease-out', style({ opacity: '0' })),
+    ]),
+  ]),
+];

--- a/frontend/src/app/core/toast/toast.component.html
+++ b/frontend/src/app/core/toast/toast.component.html
@@ -1,0 +1,10 @@
+@if (toasts.length) {
+  <div class="app-toast-list drop-shadow-lg">
+    @for (toast of toasts; track trackById) {
+      <div @toastFadeIn [class]="getClass(toast)">
+        <span>{{ getTitle(toast) | abpLocalization }}</span>
+        {{ toast.message | abpLocalization }}
+      </div>
+    }
+  </div>
+}

--- a/frontend/src/app/core/toast/toast.component.scss
+++ b/frontend/src/app/core/toast/toast.component.scss
@@ -1,0 +1,40 @@
+@use '../../../styles/variables' as *;
+
+:host {
+  display: block;
+}
+
+.app-toast-list {
+  z-index: 1001;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 1rem;
+  width: min(100%, 320px);
+  padding: 1rem;
+}
+
+.app-toast {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem;
+  background-color: $surface-1;
+  border-radius: 0.75rem;
+  font-size: 0.85rem;
+  color: $text-main-color;
+
+  span {
+    font-weight: 700;
+  }
+
+  &--success {
+    color: $success-color;
+  }
+
+  &--error {
+    color: $danger-color;
+  }
+}

--- a/frontend/src/app/core/toast/toast.component.ts
+++ b/frontend/src/app/core/toast/toast.component.ts
@@ -1,0 +1,59 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnDestroy,
+  OnInit,
+} from '@angular/core';
+import { AbpLocalizationPipe } from '@abp/ng.core';
+import { Subject, takeUntil } from 'rxjs';
+import { Toast } from './toast.model';
+import { ToastService } from './toast.service';
+import { toastAnimation } from './toast.animation';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  imports: [CommonModule, AbpLocalizationPipe],
+  templateUrl: './toast.component.html',
+  styleUrls: ['./toast.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [toastAnimation],
+})
+export class ToastComponent implements OnInit, OnDestroy {
+  toasts: Toast[] = [];
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private readonly toastService: ToastService,
+    private readonly cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit(): void {
+    this.toastService
+      .getToasts()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(toasts => {
+        this.toasts = toasts;
+        this.cdr.detectChanges();
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+  }
+
+  getClass(toast: Toast): string {
+    return `app-toast app-toast--${toast.type}`;
+  }
+
+  getTitle(toast: Toast): string {
+    return toast.title ?? `::Toast:${toast.type}:DefaultTitle`;
+  }
+
+  trackById(index: number, toast: Toast): number {
+    return toast.id;
+  }
+}

--- a/frontend/src/app/core/toast/toast.model.ts
+++ b/frontend/src/app/core/toast/toast.model.ts
@@ -1,0 +1,25 @@
+export type ToastType = 'success' | 'error';
+
+const TOAST_DEFAULT_DURATION = 5000;
+
+export interface ToastOptions {
+  message: string;
+  title?: string;
+  duration?: number;
+}
+
+export class Toast implements ToastOptions {
+  type: ToastType;
+  id: number;
+  message: string;
+  title?: string;
+  duration?: number;
+
+  constructor(type: ToastType, options: ToastOptions) {
+    this.type = type;
+    this.id = Math.round(Math.random() * 100000);
+    this.message = options.message;
+    this.title = options.title;
+    this.duration = options.duration ?? TOAST_DEFAULT_DURATION;
+  }
+}

--- a/frontend/src/app/core/toast/toast.service.ts
+++ b/frontend/src/app/core/toast/toast.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { Observable, ReplaySubject } from 'rxjs';
+import { Toast, ToastOptions } from './toast.model';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private readonly toasts: Toast[] = [];
+  private readonly toasts$ = new ReplaySubject<Toast[]>(1);
+
+  getToasts(): Observable<Toast[]> {
+    return this.toasts$.asObservable();
+  }
+
+  success(options: ToastOptions): void {
+    this.show(new Toast('success', options));
+  }
+
+  error(options: ToastOptions): void {
+    this.show(new Toast('error', options));
+  }
+
+  hide(id: number): void {
+    const index = this.toasts.findIndex(t => t.id === id);
+    if (index >= 0) {
+      this.toasts.splice(index, 1);
+    }
+    this.toasts$.next(this.toasts);
+  }
+
+  private show(toast: Toast): void {
+    this.toasts.push(toast);
+    this.toasts$.next(this.toasts);
+    if (toast.duration != null) {
+      setTimeout(() => this.hide(toast.id), toast.duration);
+    }
+  }
+}

--- a/frontend/src/app/layout/app-layout.component.html
+++ b/frontend/src/app/layout/app-layout.component.html
@@ -91,4 +91,5 @@
       <router-outlet name="modal"></router-outlet>
     </main>
   </div>
+  <app-toast></app-toast>
 </div>

--- a/frontend/src/app/layout/app-layout.component.ts
+++ b/frontend/src/app/layout/app-layout.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { AppHeaderComponent } from './header/header.component';
+import { ToastComponent } from '../core/toast/toast.component';
 
 type NavItem = {
   id: string;
@@ -18,7 +19,7 @@ type NavItem = {
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [CommonModule, RouterModule, NgOptimizedImage, AppHeaderComponent],
+  imports: [CommonModule, RouterModule, NgOptimizedImage, AppHeaderComponent, ToastComponent],
   templateUrl: './app-layout.component.html',
   styleUrls: ['./app-layout.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,6 +1,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { httpErrorInterceptor } from './app/core/interceptors/http-error.interceptor';
 import { provideAbpCore, withOptions } from '@abp/ng.core';
 import { provideAbpOAuth } from '@abp/ng.oauth';
 import { registerLocale } from '@abp/ng.core/locale';
@@ -11,7 +12,7 @@ import { environment } from './environments/environment';
 bootstrapApplication(AppComponent, {
   providers: [
     provideRouter(routes),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([httpErrorInterceptor])),
     provideAbpCore(
       withOptions({
         environment,


### PR DESCRIPTION
## Summary
- add toast service and component for notifications
- add HTTP error interceptor to display toasts and redirect on 401/403
- include toast container in admin layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c08e2eb658832188b2b6876536350b