### PR TITLE
feat(projects): add project list cards with skeleton and stubs

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -25,7 +25,7 @@ export const routes: Routes = [
       {
         path: 'projects',
         loadComponent: () =>
-          import('./pages/projects/projects.component').then(m => m.ProjectsComponent),
+          import('./pages/projects-list/projects-list.component').then(m => m.ProjectsListComponent),
       },
       {
         path: 'projects/new',

--- a/frontend/src/app/pages/projects-list/components/project-card/project-card.component.html
+++ b/frontend/src/app/pages/projects-list/components/project-card/project-card.component.html
@@ -1,0 +1,46 @@
+<article class="project-card">
+  <header class="project-card__header">
+    <h3 class="project-card__title">{{ project.name }}</h3>
+    <p class="project-card__description" *ngIf="project.description">{{ project.description }}</p>
+  </header>
+
+  <section class="project-card__section">
+    <div class="project-card__section-title">Repositories</div>
+
+    <div class="project-card__repo-list">
+      @if (repoMeta().length === 0) {
+        <div class="project-card__repo-empty">No repositories yet</div>
+      } @else {
+        @for (r of repoMeta(); track r.id) {
+          <a class="project-card__repo" [href]="r.url" target="_blank" rel="noopener">
+            <img
+              class="project-card__repo-icon"
+              [src]="'assets/images/git/' + (r.provider === 'GitHub' ? 'github' : r.provider === 'GitLab' ? 'gitlab' : r.provider === 'Bitbucket' ? 'bitbucket' : 'git-default') + '.svg'"
+              alt=""
+            />
+            <span class="project-card__repo-name">{{ r.name }}</span>
+          </a>
+        }
+      }
+    </div>
+  </section>
+
+  <section class="project-card__section">
+    <div class="project-card__section-title">Pipelines</div>
+
+    <div class="project-card__pipeline-list">
+      @if (project.pipelines.length === 0) {
+        <div class="project-card__pipeline-empty">No pipelines yet</div>
+      } @else {
+        @for (p of project.pipelines; track p.id) {
+          <div class="project-card__pipeline">
+            <span class="project-card__pipeline-name">{{ p.name }}</span>
+            <span class="project-card__pipeline-meta" *ngIf="p.lastRun as lr">
+              last run: {{ lr | date:'MM/dd/yyyy, hh:mm a' }}
+            </span>
+          </div>
+        }
+      }
+    </div>
+  </section>
+</article>

--- a/frontend/src/app/pages/projects-list/components/project-card/project-card.component.scss
+++ b/frontend/src/app/pages/projects-list/components/project-card/project-card.component.scss
@@ -1,0 +1,81 @@
+.project-card {
+  border: 1px solid rgba(255,255,255,.08);
+  background: rgba(255,255,255,.03);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+
+  &__header {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  &__title {
+    font-weight: 700;
+    color: rgba(255,255,255,.95);
+  }
+
+  &__description {
+    color: rgba(255,255,255,.6);
+    font-size: 0.875rem;
+  }
+
+  &__section {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  &__section-title {
+    font-size: 0.75rem;
+    color: rgba(255,255,255,.6);
+    text-transform: uppercase;
+    letter-spacing: .06em;
+  }
+
+  &__repo-list,
+  &__pipeline-list {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  &__repo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: .375rem .5rem;
+    border-radius: .5rem;
+    background: rgba(255,255,255,.04);
+    border: 1px solid rgba(255,255,255,.06);
+
+    &-icon {
+      width: 16px;
+      height: 16px;
+      opacity: .9;
+    }
+
+    &-name {
+      color: rgba(255,255,255,.9);
+      font-size: .875rem;
+    }
+  }
+
+  &__repo-empty,
+  &__pipeline-empty {
+    color: rgba(255,255,255,.6);
+    font-size: .875rem;
+  }
+
+  &__pipeline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .375rem .5rem;
+    border-radius: .5rem;
+    background: rgba(255,255,255,.02);
+    border: 1px solid rgba(255,255,255,.04);
+
+    &-name { color: rgba(255,255,255,.9); }
+    &-meta { color: rgba(255,255,255,.6); font-size: .75rem; }
+  }
+}

--- a/frontend/src/app/pages/projects-list/components/project-card/project-card.component.ts
+++ b/frontend/src/app/pages/projects-list/components/project-card/project-card.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, Input, computed } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+
+export type VcsProvider = 'GitHub' | 'GitLab' | 'Bitbucket';
+
+export interface ProjectListItem {
+  id: string;
+  name: string;
+  description?: string;
+  repositories: Array<{ id: string; name: string; url: string }>;
+  pipelines: Array<{ id: string; name: string; lastRun?: string | null }>;
+}
+
+@Component({
+  selector: 'app-project-card',
+  standalone: true,
+  imports: [CommonModule, DatePipe],
+  templateUrl: './project-card.component.html',
+  styleUrls: ['./project-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectCardComponent {
+  @Input({ required: true }) public project!: ProjectListItem;
+
+  // локально, не выносить
+  private providerFromUrl(url?: string): VcsProvider | undefined {
+    if (!url) return undefined;
+    if (url.includes('github.com')) return 'GitHub';
+    if (url.includes('gitlab.com')) return 'GitLab';
+    if (url.includes('bitbucket.org')) return 'Bitbucket';
+    return undefined;
+  }
+
+  public readonly repoMeta = computed(() => {
+    const repos = this.project?.repositories ?? [];
+    return repos.map(r => ({
+      ...r,
+      provider: this.providerFromUrl(r.url),
+    }));
+  });
+}

--- a/frontend/src/app/pages/projects-list/projects-list.component.html
+++ b/frontend/src/app/pages/projects-list/projects-list.component.html
@@ -1,0 +1,28 @@
+<div class="projects-page">
+  <header class="projects-page__header">
+    <h1 class="projects-page__title">Projects</h1>
+    <div class="projects-page__actions">
+      <button type="button" class="projects-page__create" (click)="onCreateProject()">Create Project</button>
+    </div>
+  </header>
+
+  @if (loading()) {
+    <div class="projects-page__grid">
+      @for (_ of [1,2,3,4,5,6]; track _) {
+        <div class="projects-page__card" appSkeleton="true"></div>
+      }
+    </div>
+  } @else if (error()) {
+    <app-stub kind="default" (primary)="onCreateProject()"
+              [overrideConfig]="{ title: 'Failed to load', description: 'Please try again.' , primaryLabel: 'Retry' }">
+    </app-stub>
+  } @else if (items().length === 0) {
+    <app-stub kind="projects" (primary)="onCreateProject()"></app-stub>
+  } @else {
+    <div class="projects-page__grid">
+      @for (p of items(); track p.id) {
+        <app-project-card [project]="p" class="projects-page__card"></app-project-card>
+      }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/projects-list/projects-list.component.scss
+++ b/frontend/src/app/pages/projects-list/projects-list.component.scss
@@ -1,0 +1,42 @@
+.projects-page {
+  display: grid;
+  gap: 1rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    font-weight: 800;
+    color: rgba(255,255,255,.95);
+    font-size: 1.375rem;
+  }
+
+  &__actions { display: flex; gap: .5rem; }
+
+  &__create {
+    height: 2.25rem;
+    padding: 0 .875rem;
+    border-radius: .5rem;
+    background: #2563eb;
+    color: white;
+    border: 1px solid rgba(0,0,0,.2);
+    cursor: pointer;
+    transition: background .15s ease;
+
+    &:hover { background: #1d4ed8; }
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: .75rem;
+  }
+
+  &__card {
+    border-radius: .75rem;
+    min-height: 164px; /* для скелетона */
+  }
+}

--- a/frontend/src/app/pages/projects-list/projects-list.component.ts
+++ b/frontend/src/app/pages/projects-list/projects-list.component.ts
@@ -1,0 +1,96 @@
+import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ProjectService } from '../../proxy/projects/project.service';
+import { RepositoryService } from '../../proxy/repositories/repository.service';
+import { PipelineService } from '../../proxy/pipelines/pipeline.service';
+import { take, map, forkJoin, of, switchMap, finalize } from 'rxjs';
+import { ToastService } from '../../core/toast/toast.service';
+import { ProjectCardComponent, ProjectListItem } from './components/project-card/project-card.component';
+import { SkeletonDirective } from '../../shared/directives/skeleton/skeleton.directive';
+import { StubComponent } from '../../shared/components/stub/stub.component';
+
+@Component({
+  selector: 'app-projects-list',
+  standalone: true,
+  imports: [CommonModule, ProjectCardComponent, SkeletonDirective, StubComponent],
+  templateUrl: './projects-list.component.html',
+  styleUrls: ['./projects-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProjectsListComponent implements OnInit {
+  private readonly projectService = inject(ProjectService);
+  private readonly repositoryService = inject(RepositoryService);
+  private readonly pipelineService = inject(PipelineService);
+  private readonly toast = inject(ToastService);
+
+  public readonly loading = signal<boolean>(true);
+  public readonly error = signal<boolean>(false);
+  public readonly items = signal<ProjectListItem[]>([]);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  // ---- public actions ----
+  public onCreateProject(): void {
+    // TODO: navigate to create-project page
+    this.toast.success({ message: 'Navigate to Create Project (TODO)' });
+  }
+
+  // ---- data loading (split by steps) ----
+  private load(): void {
+    this.loading.set(true);
+    this.error.set(false);
+
+    this.loadProjects()
+      .pipe(
+        switchMap(projects => this.loadAggregates(projects)),
+        finalize(() => this.loading.set(false)),
+        take(1),
+      )
+      .subscribe({
+        next: result => this.items.set(result),
+        error: () => {
+          this.error.set(true);
+          this.toast.error({ message: 'Failed to load projects' });
+        },
+      });
+  }
+
+  private loadProjects() {
+    return this.projectService.getList({ skipCount: 0, maxResultCount: 1000 }).pipe(
+      map(res => (res.items ?? []).map(p => ({
+        id: p.id!,
+        name: p.name ?? '',
+        description: p.description ?? '',
+      }))),
+    );
+  }
+
+  private loadAggregates(projects: Array<{ id: string; name: string; description?: string }>) {
+    if (projects.length === 0) return of([] as ProjectListItem[]);
+    const perProject$ = projects.map(p =>
+      forkJoin({
+        repos: this.repositoryService.getList({ skipCount: 0, maxResultCount: 1000 }).pipe(
+          map(res => (res.items ?? []).filter(r => r.projectId === p.id).map(r => ({
+            id: r.id!, name: r.name ?? '', url: r.url ?? '',
+          }))),
+          take(1)
+        ),
+        pipes: this.pipelineService.getList({ skipCount: 0, maxResultCount: 1000 }).pipe(
+          map(res => (res.items ?? []).filter((x: any) => (x as any).projectId === p.id).map((x: any) => ({
+            id: x.id!, name: x.name ?? x.id!.slice(0,8), lastRun: x.startedAt ?? null,
+          }))),
+          take(1)
+        ),
+      }).pipe(
+        map(({ repos, pipes }) => ({
+          id: p.id, name: p.name, description: p.description,
+          repositories: repos, pipelines: pipes,
+        }) as ProjectListItem),
+        take(1)
+      )
+    );
+    return forkJoin(perProject$);
+  }
+}

--- a/frontend/src/app/shared/components/stub/stub.component.html
+++ b/frontend/src/app/shared/components/stub/stub.component.html
@@ -1,0 +1,17 @@
+<div class="stub">
+  <div class="stub__icon" *ngIf="config.icon as i">
+    <!-- можно заменить на свою систему иконок -->
+    <i class="lucide" [attr.data-icon]="i"></i>
+  </div>
+
+  <div class="stub__title">{{ config.title }}</div>
+  <div class="stub__description" *ngIf="config.description">{{ config.description }}</div>
+
+  <button
+    class="stub__button"
+    *ngIf="config.primaryLabel"
+    type="button"
+    (click)="onPrimaryClick()">
+    {{ config.primaryLabel }}
+  </button>
+</div>

--- a/frontend/src/app/shared/components/stub/stub.component.scss
+++ b/frontend/src/app/shared/components/stub/stub.component.scss
@@ -1,0 +1,57 @@
+.stub {
+  --stub-fg: rgba(255,255,255,0.9);
+  --stub-fg-dim: rgba(255,255,255,0.6);
+  --stub-bg: rgba(255,255,255,0.04);
+  --stub-border: rgba(255,255,255,0.08);
+
+  display: grid;
+  gap: 0.5rem;
+  place-items: center;
+  text-align: center;
+  padding: 2.5rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--stub-border);
+  background: var(--stub-bg);
+
+  &__icon {
+    display: grid;
+    place-items: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 999px;
+    background: rgba(255,255,255,0.06);
+    margin-bottom: 0.25rem;
+
+    .lucide {
+      width: 1.25rem;
+      height: 1.25rem;
+      color: var(--stub-fg);
+    }
+  }
+
+  &__title {
+    font-weight: 700;
+    color: var(--stub-fg);
+    font-size: 1.125rem;
+    line-height: 1.4;
+  }
+
+  &__description {
+    color: var(--stub-fg-dim);
+    max-width: 42rem;
+  }
+
+  &__button {
+    margin-top: 0.5rem;
+    height: 2.25rem;
+    padding: 0 0.875rem;
+    border-radius: 0.5rem;
+    background: #2563eb;
+    color: white;
+    border: 1px solid rgba(0,0,0,0.2);
+    transition: background .15s ease;
+    cursor: pointer;
+
+    &:hover { background: #1d4ed8; }
+  }
+}

--- a/frontend/src/app/shared/components/stub/stub.component.ts
+++ b/frontend/src/app/shared/components/stub/stub.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { STUB_CONFIGS, StubConfig, StubKind } from './stub.model';
+
+@Component({
+  selector: 'app-stub',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './stub.component.html',
+  styleUrls: ['./stub.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StubComponent {
+  @Input({ required: true }) public kind!: StubKind;
+  @Input() public overrideConfig?: Partial<StubConfig>;
+  @Output() public primary = new EventEmitter<void>();
+
+  public get config(): StubConfig {
+    const base = STUB_CONFIGS[this.kind] ?? STUB_CONFIGS.default;
+    return { ...base, ...(this.overrideConfig ?? {}) };
+  }
+
+  public onPrimaryClick(): void {
+    this.primary.emit();
+  }
+}

--- a/frontend/src/app/shared/components/stub/stub.model.ts
+++ b/frontend/src/app/shared/components/stub/stub.model.ts
@@ -1,0 +1,27 @@
+export type StubKind = 'projects' | 'default';
+
+export interface StubConfig {
+  /** Большой заголовок */
+  title: string;
+  /** Описание под заголовком */
+  description?: string;
+  /** Имя иконки (lucide или <svg> слотом в шаблоне) */
+  icon?: string;
+  /** Текст кнопки (если отсутствует — кнопка скрыта) */
+  primaryLabel?: string;
+}
+
+/** Базовые пресеты, как в merge-sensey, без i18n для упрощения (TODO: i18n) */
+export const STUB_CONFIGS: Record<StubKind, StubConfig> = {
+  projects: {
+    title: 'No projects yet',
+    description: 'Create your first project to start connecting repositories and pipelines.',
+    icon: 'folder-plus',
+    primaryLabel: 'Create project',
+  },
+  default: {
+    title: 'Nothing here',
+    description: 'There is no data to display yet.',
+    icon: 'file-question',
+  },
+};

--- a/frontend/src/app/shared/directives/skeleton/skeleton.directive.ts
+++ b/frontend/src/app/shared/directives/skeleton/skeleton.directive.ts
@@ -1,0 +1,56 @@
+import { Directive, ElementRef, Renderer2, OnInit, OnDestroy, Input, inject } from '@angular/core';
+
+function coerceBooleanProperty(value: any): boolean {
+  return value != null && `${value}` !== 'false';
+}
+
+@Directive({
+  selector: '[appSkeleton]',
+  standalone: true,
+})
+export class SkeletonDirective implements OnInit, OnDestroy {
+  private readonly el = inject(ElementRef<HTMLElement>);
+  private readonly renderer = inject(Renderer2);
+  private resizeObserver!: ResizeObserver;
+  private _show = false;
+
+  @Input()
+  set appSkeleton(value: boolean | string | null | undefined) {
+    this._show = coerceBooleanProperty(value);
+    this.toggle();
+  }
+
+  ngOnInit(): void {
+    this.resizeObserver = new ResizeObserver(() => this.applyBoxSize());
+    this.resizeObserver.observe(this.el.nativeElement);
+    this.toggle();
+  }
+
+  ngOnDestroy(): void {
+    this.resizeObserver?.disconnect();
+    this.removeSkeletonStyles();
+  }
+
+  private toggle() {
+    if (this._show) {
+      this.applyBoxSize();
+      this.renderer.addClass(this.el.nativeElement, 'skeleton');
+    } else {
+      this.renderer.removeClass(this.el.nativeElement, 'skeleton');
+      this.removeSkeletonStyles();
+    }
+  }
+
+  private applyBoxSize() {
+    const host = this.el.nativeElement;
+    const rect = host.getBoundingClientRect();
+    this.renderer.setStyle(host, 'min-width', `${rect.width}px`);
+    this.renderer.setStyle(host, 'min-height', `${rect.height}px`);
+  }
+
+  private removeSkeletonStyles() {
+    const host = this.el.nativeElement;
+    this.renderer.removeStyle(host, 'min-width');
+    this.renderer.removeStyle(host, 'min-height');
+  }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -1,3 +1,4 @@
+@use 'styles/skeleton/skeleton';
 @use 'styles/variables' as *;
 
 @tailwind base;

--- a/frontend/src/styles/skeleton/_skeleton.scss
+++ b/frontend/src/styles/skeleton/_skeleton.scss
@@ -1,0 +1,16 @@
+.skeleton {
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background-color: rgba(255, 255, 255, 0.06);
+    animation: skeleton-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  }
+}
+
+@keyframes skeleton-pulse {
+  50% { background-color: rgba(255, 255, 255, 0.10); }
+}


### PR DESCRIPTION
## Summary
- add reusable skeleton directive and styles
- implement shared stub component for empty/error states
- display project repositories and pipelines with provider icons
- build projects list page using skeletons and stubs
- reuse existing git icons instead of duplicating assets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c244c7329083218ed5484d5875e2b8