### PR TITLE
Add pipeline indexes and cleanup

### DIFF
--- a/frontend/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.ts
+++ b/frontend/src/app/pages/pipeline-create-modal/pipeline-create-modal.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, HostListener, inject } from '@angul
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators, FormArray, FormControl } from '@angular/forms';
 import { ActivatedRoute, RouterModule, Router } from '@angular/router';
+import { TriggerTypeService } from '@/app/proxy/trigger-types/trigger-type.service';
 
 type Trigger = 'manual'|'push'|'schedule';
 type SchType = 'daily'|'weekly'|'cron';
@@ -18,9 +19,11 @@ export class PipelineCreateModalComponent {
   private fb = inject(FormBuilder);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
+  private triggerTypeService = inject(TriggerTypeService);
 
   step = 1;
   readonly projectId = this.route.snapshot.paramMap.get('projectId')!;
+  readonly triggerTypes$ = this.triggerTypeService.getList({ skipCount: 0, maxResultCount: 100 } as any);
 
   readonly form = this.fb.nonNullable.group({
     name: this.fb.nonNullable.control('', { validators: [Validators.required, Validators.minLength(3)] }),

--- a/src/Nomium.MergeSensei.Application/MergeSenseiApplicationModule.cs
+++ b/src/Nomium.MergeSensei.Application/MergeSenseiApplicationModule.cs
@@ -35,9 +35,9 @@ public class MergeSenseiApplicationModule : AbpModule
 {
     public override void ConfigureServices(ServiceConfigurationContext context)
     {
-        Configure<AbpAutoMapperOptions>(options =>
+        Configure<AbpAutoMapperOptions>(opt =>
         {
-            options.AddMaps<MergeSenseiApplicationModule>();
+            opt.AddMaps<MergeSenseiApplicationModule>(validate: true);
         });
 
         context.Services.AddScoped<IAiModelAppService, AiModelAppService>();

--- a/src/Nomium.MergeSensei.EntityFrameworkCore/Configurations/PipelineConfiguration.cs
+++ b/src/Nomium.MergeSensei.EntityFrameworkCore/Configurations/PipelineConfiguration.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Nomium.MergeSensei.Pipelines;
+using Nomium.MergeSensei.Repositories;
+using Nomium.MergeSensei.Branches;
 
 namespace Nomium.MergeSensei.Configurations;
 
@@ -16,10 +18,25 @@ public class PipelineConfiguration : IEntityTypeConfiguration<Pipeline>
         b.Property(p => p.BranchId).IsRequired();
         b.Property(p => p.TriggerTypeId).IsRequired();
 
+        b.HasIndex(p => p.ProjectId);
+        b.HasIndex(p => p.RepositoryId);
+        b.HasIndex(p => p.BranchId);
+        b.HasIndex(p => p.TriggerTypeId);
+
         b.HasMany(p => p.Agents)
          .WithOne()
          .HasForeignKey(x => x.PipelineId)
          .OnDelete(DeleteBehavior.Cascade);
+
+        b.HasOne<Repository>()
+         .WithMany()
+         .HasForeignKey(p => p.RepositoryId)
+         .OnDelete(DeleteBehavior.Restrict);
+
+        b.HasOne<Branch>()
+         .WithMany()
+         .HasForeignKey(p => p.BranchId)
+         .OnDelete(DeleteBehavior.Restrict);
     }
 }
 

--- a/src/Nomium.MergeSensei.EntityFrameworkCore/Migrations/20250728010000_Pipeline_AddIndexes_FK.cs
+++ b/src/Nomium.MergeSensei.EntityFrameworkCore/Migrations/20250728010000_Pipeline_AddIndexes_FK.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nomium.MergeSensei.Migrations
+{
+    public partial class Pipeline_AddIndexes_FK : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Pipelines_ProjectId",
+                table: "Pipelines",
+                column: "ProjectId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Pipelines_RepositoryId",
+                table: "Pipelines",
+                column: "RepositoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Pipelines_BranchId",
+                table: "Pipelines",
+                column: "BranchId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Pipelines_TriggerTypeId",
+                table: "Pipelines",
+                column: "TriggerTypeId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Pipelines_Repositories_RepositoryId",
+                table: "Pipelines",
+                column: "RepositoryId",
+                principalTable: "Repositories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Pipelines_Branches_BranchId",
+                table: "Pipelines",
+                column: "BranchId",
+                principalTable: "Branches",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Pipelines_Repositories_RepositoryId",
+                table: "Pipelines");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Pipelines_Branches_BranchId",
+                table: "Pipelines");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Pipelines_ProjectId",
+                table: "Pipelines");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Pipelines_RepositoryId",
+                table: "Pipelines");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Pipelines_BranchId",
+                table: "Pipelines");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Pipelines_TriggerTypeId",
+                table: "Pipelines");
+        }
+    }
+}

--- a/src/Nomium.MergeSensei.EntityFrameworkCore/Migrations/20250728011000_Pipeline_DropLegacyColumns.cs
+++ b/src/Nomium.MergeSensei.EntityFrameworkCore/Migrations/20250728011000_Pipeline_DropLegacyColumns.cs
@@ -1,0 +1,59 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nomium.MergeSensei.Migrations
+{
+    public partial class Pipeline_DropLegacyColumns : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Pipelines");
+
+            migrationBuilder.DropColumn(
+                name: "StartedAt",
+                table: "Pipelines");
+
+            migrationBuilder.DropColumn(
+                name: "FinishedAt",
+                table: "Pipelines");
+
+            migrationBuilder.DropColumn(
+                name: "Duration",
+                table: "Pipelines");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Pipelines",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "StartedAt",
+                table: "Pipelines",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime?>(
+                name: "FinishedAt",
+                table: "Pipelines",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int?>(
+                name: "Duration",
+                table: "Pipelines",
+                type: "integer",
+                nullable: true);
+        }
+    }
+}

--- a/src/Nomium.MergeSensei.EntityFrameworkCore/Migrations/MergeSenseiDbContextModelSnapshot.cs
+++ b/src/Nomium.MergeSensei.EntityFrameworkCore/Migrations/MergeSenseiDbContextModelSnapshot.cs
@@ -315,16 +315,10 @@ namespace Nomium.MergeSensei.Migrations
                         .HasColumnType("timestamp without time zone")
                         .HasColumnName("DeletionTime");
 
-                    b.Property<int?>("Duration")
-                        .HasColumnType("integer");
-
                     b.Property<string>("ExtraProperties")
                         .IsRequired()
                         .HasColumnType("text")
                         .HasColumnName("ExtraProperties");
-
-                    b.Property<DateTime?>("FinishedAt")
-                        .HasColumnType("timestamp without time zone");
 
                     b.Property<bool>("IsDeleted")
                         .ValueGeneratedOnAdd()
@@ -360,19 +354,20 @@ namespace Nomium.MergeSensei.Migrations
                     b.Property<long>("TriggerTypeId")
                         .HasColumnType("bigint");
 
-                    b.Property<DateTime>("StartedAt")
-                        .HasColumnType("timestamp without time zone");
-
-                    b.Property<string>("Status")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
 
                     b.Property<Guid?>("TenantId")
                         .HasColumnType("uuid")
                         .HasColumnName("TenantId");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("BranchId");
+
+                    b.HasIndex("ProjectId");
+
+                    b.HasIndex("RepositoryId");
+
+                    b.HasIndex("TriggerTypeId");
 
                     b.ToTable("Pipelines", (string)null);
                 });
@@ -2577,6 +2572,30 @@ namespace Nomium.MergeSensei.Migrations
                         .WithMany()
                         .HasForeignKey("TypeId")
                         .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Nomium.MergeSensei.Pipelines.Pipeline", b =>
+                {
+                    b.HasOne("Nomium.MergeSensei.Entities.Branch", null)
+                        .WithMany()
+                        .HasForeignKey("BranchId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("Nomium.MergeSensei.Entities.Repository", null)
+                        .WithMany()
+                        .HasForeignKey("RepositoryId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+                });
+
+            modelBuilder.Entity("Nomium.MergeSensei.Pipelines.PipelineAgent", b =>
+                {
+                    b.HasOne("Nomium.MergeSensei.Pipelines.Pipeline", null)
+                        .WithMany()
+                        .HasForeignKey("PipelineId")
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 


### PR DESCRIPTION
## Summary
- validate AutoMapper profiles in application module
- index and relate pipelines to repositories and branches
- drop legacy pipeline columns and wire up proxy service in pipeline modal

## Testing
- `dotnet ef migrations add Pipeline_AddIndexes_FK --project src/Nomium.MergeSensei.EntityFrameworkCore --startup-project src/Nomium.MergeSensei.HttpApi.Host` *(fails: command not found)*
- `dotnet ef database update --project src/Nomium.MergeSensei.EntityFrameworkCore --startup-project src/Nomium.MergeSensei.HttpApi.Host` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2822dccd08321bb4f260ea02a2837